### PR TITLE
Add qb-phone & typo fix for screenshot-basic

### DIFF
--- a/integrations/qbcore-phone.md
+++ b/integrations/qbcore-phone.md
@@ -1,2 +1,64 @@
 # QBCore Phone
 
+Every standard QB-Core server comes with `screenshot-basic` and `qb-phone` out of the box. This at present is configured to use Discord as a CDN.
+
+To _upgrade_ to Fivemerr, follow these simple instructions below:
+
+## Server File Change
+- Navigate to `qb-phone/blob/main/server/main.lua`
+- Update `WebHook` to the Fivemerr API url based on your token type.
+  - Missed the Fivemerr setup? You can find it [here](https://docs.fivemerr.com/)
+
+## Client File Change
+- Navigate to `qb-phone/blob/main/client/main.lua`
+- Search for `exports['screenshot-basic']:requestScreenshotUpload` within this file
+- You should find something _similar_ to this:
+```lua
+QBCore.Functions.TriggerCallback('qb-phone:server:GetWebhook', function(hook)
+    if not hook then
+        QBCore.Functions.Notify('Camera not setup', 'error')
+        return
+    end
+    exports['screenshot-basic']:requestScreenshotUpload(tostring(hook), 'files[]', function(data)
+        SaveToInternalGallery()
+        local image = json.decode(data)
+        DestroyMobilePhone()
+        CellCamActivate(false, false)
+        TriggerServerEvent('qb-phone:server:addImageToGallery', image.attachments[1].proxy_url)
+        Wait(400)
+        TriggerServerEvent('qb-phone:server:getImageFromGallery')
+        cb(json.encode(image.attachments[1].proxy_url))
+        takePhoto = false
+    end)
+end)
+```
+
+Found it? Great! 
+
+Now update it to this:
+```lua
+QBCore.Functions.TriggerCallback('qb-phone:server:GetWebhook', function(hook)
+    if not hook then
+        QBCore.Functions.Notify('Camera not setup', 'error')
+        return
+    end
+    exports['screenshot-basic']:requestScreenshotUpload(tostring(hook), 'file', {
+        headers = {
+            Authorization = 'f4b84fca37aec220b464f965c7e1b030'
+        } 
+    }, function(data)
+            SaveToInternalGallery()
+            local image = json.decode(data)
+            local link = (image and image.url) or 'invalid_url'
+            DestroyMobilePhone()
+            CellCamActivate(false, false)
+            TriggerServerEvent('qb-phone:server:addImageToGallery', link)
+            Wait(400)
+            TriggerServerEvent('qb-phone:server:getImageFromGallery')
+            cb(json.encode(link))
+            takePhoto = false
+    end)
+end)
+```
+
+Restart your `qb-phone` **or** server and you're done 🎉!

--- a/integrations/screenshot-basic.md
+++ b/integrations/screenshot-basic.md
@@ -12,7 +12,7 @@ exports['screenshot-basic']:requestScreenshotUpload('https://api.fivemerr.com/v1
     encoding = 'png'
 }, function(data)
     local resp = json.decode(data)
-    local link = (resp and resp.url) or 'inalid_url'
+    local link = (resp and resp.url) or 'invalid_url'
     print(link)
 end)
 ```


### PR DESCRIPTION
Addressing the blank qb-phone docs, fixed a typo as well on `screenshot-basic`.