### PR TITLE
fix(docs): ShareX integration images

### DIFF
--- a/script-integrations/sharex.md
+++ b/script-integrations/sharex.md
@@ -7,18 +7,18 @@ This will allow you to utilize ShareX to automatically upload your screenshots f
 * Open ShareX main application
 * Open Destinations > Custom Uploader Settings
 * Create New Uploader
-* Set name Fivemerr
-* Request URL https://api.fivemerr.com/v1/media/images (Must be typed in)
+* Set name to Fivemerr
+* Request URL: https://api.fivemerr.com/v1/media/images (Must be typed in)
 * Header Name: Authorization
 * Value: Your\_Api\_Key (Add your API Key here)
-* File Form Name file
+* File Form Name: file
 * URL {json:url}
 * Change destination to Custom Image Uploader
 
 **Please see attached images to see a detailed outline of how it should look**
 
-<figure><img src="https://files.fivemerr.com/images/0b9b20b6-f2d4-412c-b119-ca459ac3feb7.png" alt=""><figcaption><p>Custom Uploader Settings</p></figcaption></figure>
+<figure><img src="https://files.fivemerr.com/images/b95e2338-caf4-4867-bb1e-48f8d83981f8.png" alt=""><figcaption><p>Custom Uploader Settings</p></figcaption></figure>
 
-<figure><img src="https://files.fivemerr.com/images/7fa3ba9e-a0fb-4294-a7ba-148ad22aa24b.png" alt=""><figcaption><p>Correct Setting Examples</p></figcaption></figure>
+<figure><img src="https://files.fivemerr.com/images/7aa68d84-4fff-4c19-a415-8db1ad935d8d.png" alt=""><figcaption><p>Image Uploader Settings</p></figcaption></figure>
 
-<figure><img src="https://files.fivemerr.com/images/8cafafde-ef3f-458c-bff9-0996f3469d8c.png" alt=""><figcaption><p>Image Uploader Settings</p></figcaption></figure>
+<figure><img src="https://files.fivemerr.com/images/e2ff6b4b-e006-4d33-a74a-852792763bcc.png" alt=""><figcaption><p>After Capture Tasks Settings</p></figcaption></figure>


### PR DESCRIPTION
The images in the docs were missing and returning a `404` so I updated them and I also fixed some small stuff in the "Configuration" part of the doc